### PR TITLE
Deleted displaying the warning message when close the Runic Draw without interpretation

### DIFF
--- a/app/src/main/java/com/tnco/runar/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/tnco/runar/ui/activity/MainActivity.kt
@@ -196,7 +196,7 @@ class MainActivity : AppCompatActivity(), Navigator, AudioManager.OnAudioFocusCh
             }
             is LayoutInterpretationFavFragment -> navigateToFavAndShowBottomNavBar()
             is AboutAppFragment -> navigateToSettings()
-            is LayoutInitFragment -> showDialog("layout_init")
+            is LayoutInitFragment -> navigateToDefaultAndShowBottomNavBar()
             is LayoutInterpretationFragment -> showDialog("layout_interpretation")
             is LayoutProcessingFragment -> showDialog("layout_processing")
             !is LayoutDescriptionFragment -> showDialog("navigation_error")

--- a/app/src/main/java/com/tnco/runar/ui/fragment/LayoutInitFragment.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/LayoutInitFragment.kt
@@ -228,7 +228,7 @@ class LayoutInitFragment : Fragment(R.layout.fragment_layout_init), View.OnClick
 
         when (v?.id) {
             R.id.exit_button -> {
-                navigator?.showDialog("layout_init")
+                navigator?.navigateToDefaultAndShowBottomNavBar()
             }
             R.id.description_button_frame -> {
                 val result = slotChanger()


### PR DESCRIPTION
Удалил предупреждающее диалоговое окно, которое появлялось при закрытии руны без толкования/интерпретации.

Путь: Расклады -> Открыть любую руну -> Начать расклад (если не стоит отметка "Больше не показывать") -> Закрыть выбранную руну.