### PR TITLE
add analytics events for generator

### DIFF
--- a/app/src/main/java/com/tnco/runar/ui/fragment/BackgroundAdapter.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/BackgroundAdapter.kt
@@ -1,4 +1,4 @@
-package com.tnco.runar.ui.fragments
+package com.tnco.runar.ui.fragment
 
 import android.view.LayoutInflater
 import android.view.View
@@ -18,7 +18,7 @@ class BackgroundAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BackgroundViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        val itemView = inflater.inflate(R.layout.backgroung_generato_selected,parent,false)
+        val itemView = inflater.inflate(R.layout.backgroung_generato_selected, parent, false)
         val holder = BackgroundViewHolder(itemView)
         itemView.setOnClickListener {
             selectBackground(holder.adapterPosition)
@@ -35,8 +35,10 @@ class BackgroundAdapter(
         progressBar.visibility = if (list[position].img != null) View.GONE else View.VISIBLE
         img.setImageBitmap(list[position].img)
         checkBox.visibility = if (list[position].isSelected) View.VISIBLE else View.GONE
-        frameLayout.setBackgroundResource(if (list[position].isSelected) R.drawable.backround_background_selected
-                                                      else R.drawable.backround_background)
+        frameLayout.setBackgroundResource(
+            if (list[position].isSelected) R.drawable.backround_background_selected
+            else R.drawable.backround_background
+        )
     }
 
     fun updateData(list: List<BackgroundInfo>) {

--- a/app/src/main/java/com/tnco/runar/ui/fragment/GeneratorBackground.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/GeneratorBackground.kt
@@ -1,4 +1,4 @@
-package com.tnco.runar.ui.fragments
+package com.tnco.runar.ui.fragment
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
@@ -11,6 +11,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.tnco.runar.R
+import com.tnco.runar.analytics.AnalyticsHelper
+import com.tnco.runar.enums.AnalyticsEvent
 import com.tnco.runar.ui.activity.MainActivity
 import com.tnco.runar.ui.viewmodel.MainViewModel
 
@@ -29,10 +31,11 @@ class GeneratorBackground : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        AnalyticsHelper.sendEvent(AnalyticsEvent.GENERATOR_PATTERN_SELECTION_BACKGROUND)
         progressBar = view.findViewById(R.id.generatorProgressBar)
         pointLayout = view.findViewById(R.id.points)
         btn_next = view.findViewById<TextView>(R.id.button_next)
-        textSelectBackground  = view.findViewById<TextView>(R.id.textSelectBackground)
+        textSelectBackground = view.findViewById<TextView>(R.id.textSelectBackground)
         textSelectBackground.visibility = View.GONE
         btn_next.setOnClickListener {
             activity?.supportFragmentManager?.beginTransaction()
@@ -40,7 +43,7 @@ class GeneratorBackground : Fragment() {
                 ?.commit()
         }
 
-        if (viewModel.backgroundInfo.value!!.isEmpty()){
+        if (viewModel.backgroundInfo.value!!.isEmpty()) {
             viewModel.getBackgroundInfo()
         }
         backgroundImgRecyclerView = view.findViewById(R.id.backgroundImgRecyclerView)
@@ -50,38 +53,39 @@ class GeneratorBackground : Fragment() {
         backgroundImgRecyclerView.layoutManager = layoutManager
         backgroundImgRecyclerView.setOnScrollChangeListener { _, _, _, _, _ ->
 
-           var pos = layoutManager.findFirstCompletelyVisibleItemPosition()
+            var pos = layoutManager.findFirstCompletelyVisibleItemPosition()
 
-                if (hasSelected){
-                    pos = viewModel.backgroundInfo.value!!.indexOfFirst { it.isSelected }
+            if (hasSelected) {
+                pos = viewModel.backgroundInfo.value!!.indexOfFirst { it.isSelected }
+            }
+
+            if (pos >= 0) {
+                for (i in pointsList.indices) {
+                    pointsList[i].setImageResource(
+                        if (i == pos) R.drawable.ic_point_selected
+                        else R.drawable.ic_point_deselected
+                    )
                 }
-
-           if (pos >= 0) {
-               for (i in pointsList.indices) {
-                   pointsList[i].setImageResource(
-                       if (i == pos) R.drawable.ic_point_selected
-                       else R.drawable.ic_point_deselected
-                   )
-               }
-               pointLayout.invalidate()
-           }
+                pointLayout.invalidate()
+            }
 
         }
 
 
         viewModel.backgroundInfo.observe(activity as MainActivity, Observer {
-            if (viewModel.backgroundInfo.value!!.isNotEmpty()){
+            if (viewModel.backgroundInfo.value!!.isNotEmpty()) {
                 progressBar.visibility = View.GONE
                 textSelectBackground.visibility = if (!hasSelected) View.VISIBLE else View.GONE
                 pointsList.clear()
                 pointLayout.removeAllViews()
                 val inflater = LayoutInflater.from(view.context)
-                for (i in 0..viewModel.backgroundInfo.value!!.size - 1){
-                    val point = inflater.inflate(R.layout.point_image_view,pointLayout,false) as ImageView
-                    if (!hasSelected){
+                for (i in 0..viewModel.backgroundInfo.value!!.size - 1) {
+                    val point =
+                        inflater.inflate(R.layout.point_image_view, pointLayout, false) as ImageView
+                    if (!hasSelected) {
                         var pos = layoutManager.findFirstCompletelyVisibleItemPosition()
-                        if (pos < 0) pos =0
-                        point.setImageResource(if (i==pos) R.drawable.ic_point_selected else R.drawable.ic_point_deselected)
+                        if (pos < 0) pos = 0
+                        point.setImageResource(if (i == pos) R.drawable.ic_point_selected else R.drawable.ic_point_deselected)
                     } else {
                         point.setImageResource(if (viewModel.backgroundInfo.value!![i].isSelected) R.drawable.ic_point_selected else R.drawable.ic_point_deselected)
                     }
@@ -105,12 +109,12 @@ class GeneratorBackground : Fragment() {
         return inflater.inflate(R.layout.fragment_generator_background, container, false)
     }
 
-    private fun selectBackground(position: Int){
+    private fun selectBackground(position: Int) {
         val data = viewModel.backgroundInfo.value!!
 
 
-        for (i in data.indices){
-            if (i != position){
+        for (i in data.indices) {
+            if (i != position) {
                 data[i].isSelected = false
             } else {
                 data[position].isSelected = !data[position].isSelected
@@ -118,7 +122,7 @@ class GeneratorBackground : Fragment() {
         }
 
         hasSelected = data.filter { it.isSelected }.count() > 0
-        if (hasSelected){
+        if (hasSelected) {
             btn_next.visibility = View.VISIBLE
             textSelectBackground.visibility = View.GONE
         } else {

--- a/app/src/main/java/com/tnco/runar/ui/fragment/GeneratorFinal.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/GeneratorFinal.kt
@@ -1,4 +1,4 @@
-package com.tnco.runar.ui.fragments
+package com.tnco.runar.ui.fragment
 
 import android.Manifest
 import android.content.ContentValues
@@ -20,8 +20,9 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.tnco.runar.R
+import com.tnco.runar.analytics.AnalyticsHelper
+import com.tnco.runar.enums.AnalyticsEvent
 import com.tnco.runar.ui.activity.MainActivity
-import com.tnco.runar.ui.fragment.GeneratorFragment
 import com.tnco.runar.ui.viewmodel.MainViewModel
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -29,7 +30,7 @@ import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.util.*
 
-class GeneratorFinal: Fragment() {
+class GeneratorFinal : Fragment() {
     val REQUEST_PERMISSION_CODE = 111
     private lateinit var viewModel: MainViewModel
     lateinit var saveImg: ImageView
@@ -64,11 +65,13 @@ class GeneratorFinal: Fragment() {
 //        instagram = view.findViewById(R.id.instagram)
 
         shareImg.setOnClickListener {
+            AnalyticsHelper.sendEvent(AnalyticsEvent.GENERATOR_PATTERN_SHARED)
             val bytes = ByteArrayOutputStream()
             val bmp = (imgFinal.drawable as BitmapDrawable).bitmap
             val title = resources.getString(R.string.share_title)
             bmp.compress(Bitmap.CompressFormat.JPEG, 100, bytes)
-            val path = MediaStore.Images.Media.insertImage(context?.contentResolver, bmp, title, null)
+            val path =
+                MediaStore.Images.Media.insertImage(context?.contentResolver, bmp, title, null)
             val uri = Uri.parse(path.toString())
             val shareIntent: Intent = Intent().apply {
                 action = Intent.ACTION_SEND
@@ -89,38 +92,44 @@ class GeneratorFinal: Fragment() {
 
 
         saveImg.setOnClickListener {
+            AnalyticsHelper.sendEvent(AnalyticsEvent.GENERATOR_PATTERN_SAVED)
             val fileName = generateFileName()
             val bmp = (imgFinal.drawable as BitmapDrawable).bitmap
             saveImg.visibility = View.INVISIBLE
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q){
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 val contentValues = ContentValues().apply {
                     put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
                     put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
                     put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
                 }
                 val resolver = activity!!.contentResolver
-                val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI,contentValues)
+                val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
                 if (uri != null) {
-                    bmp.compress(Bitmap.CompressFormat.JPEG,100,resolver.openOutputStream(uri))
+                    bmp.compress(Bitmap.CompressFormat.JPEG, 100, resolver.openOutputStream(uri))
                 }
                 saveImg.visibility = View.VISIBLE
                 val msg = resources.getString(R.string.image_saved)
-                Toast.makeText(requireContext(),msg,Toast.LENGTH_LONG).show()
+                Toast.makeText(requireContext(), msg, Toast.LENGTH_LONG).show()
             } else {
-                if (ContextCompat.checkSelfPermission(requireActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                    != PackageManager.PERMISSION_GRANTED){
+                if (ContextCompat.checkSelfPermission(
+                        requireActivity(),
+                        Manifest.permission.WRITE_EXTERNAL_STORAGE
+                    )
+                    != PackageManager.PERMISSION_GRANTED
+                ) {
                     requestPermissions(Array(1) {
                         Manifest.permission.WRITE_EXTERNAL_STORAGE
-                    },REQUEST_PERMISSION_CODE)
+                    }, REQUEST_PERMISSION_CODE)
                 } else {
-                    val path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-                    val filePath = File(path,fileName)
+                    val path =
+                        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+                    val filePath = File(path, fileName)
                     val os = FileOutputStream(filePath)
-                    bmp.compress(Bitmap.CompressFormat.JPEG,100,os)
+                    bmp.compress(Bitmap.CompressFormat.JPEG, 100, os)
                     os.close()
                     saveImg.visibility = View.VISIBLE
                     val msg = resources.getString(R.string.image_saved)
-                    Toast.makeText(requireContext(),msg,Toast.LENGTH_LONG).show()
+                    Toast.makeText(requireContext(), msg, Toast.LENGTH_LONG).show()
                 }
 
             }
@@ -134,28 +143,30 @@ class GeneratorFinal: Fragment() {
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == REQUEST_PERMISSION_CODE){
-            if (grantResults.get(0) == PackageManager.PERMISSION_GRANTED){
+        if (requestCode == REQUEST_PERMISSION_CODE) {
+            if (grantResults.get(0) == PackageManager.PERMISSION_GRANTED) {
                 val fileName = generateFileName()
                 val bmp = (imgFinal.drawable as BitmapDrawable).bitmap
-                val path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-                val filePath = File(path,fileName)
+                val path =
+                    Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+                val filePath = File(path, fileName)
                 val os = FileOutputStream(filePath)
-                bmp.compress(Bitmap.CompressFormat.JPEG,100,os)
+                bmp.compress(Bitmap.CompressFormat.JPEG, 100, os)
                 os.close()
                 saveImg.visibility = View.VISIBLE
                 val msg = resources.getString(R.string.image_saved)
-                Toast.makeText(requireContext(),msg,Toast.LENGTH_LONG).show()
+                Toast.makeText(requireContext(), msg, Toast.LENGTH_LONG).show()
             }
         }
     }
 
-    fun generateFileName(): String{
-       val time = System.currentTimeMillis()
-       val formatter = SimpleDateFormat("dd:MM:yyyy_HH:mm:ss", Locale.getDefault())
-       val date = formatter.format(time)
-       return "rune_$date.jpg"
+    fun generateFileName(): String {
+        val time = System.currentTimeMillis()
+        val formatter = SimpleDateFormat("dd:MM:yyyy_HH:mm:ss", Locale.getDefault())
+        val date = formatter.format(time)
+        return "rune_$date.jpg"
     }
+
     override fun onDestroyView() {
         super.onDestroyView()
         (activity as MainActivity).showBottomBar()

--- a/app/src/main/java/com/tnco/runar/ui/fragment/GeneratorFragment.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/GeneratorFragment.kt
@@ -16,7 +16,7 @@ import com.tnco.runar.ui.activity.MainActivity
 import com.tnco.runar.ui.viewmodel.MainViewModel
 
 
-class GeneratorFragment : Fragment(){
+class GeneratorFragment : Fragment() {
     val viewModel: MainViewModel by viewModels()
 
     private var _binding: FragmerntLayoutGeneratorBinding? = null
@@ -29,7 +29,6 @@ class GeneratorFragment : Fragment(){
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmerntLayoutGeneratorBinding.inflate(inflater, container, false)
-        AnalyticsHelper.sendEvent(AnalyticsEvent.GENERATOR_OPENED)
         viewModel.fontSize.observeOnce(this) {
             binding.tvToolbar.setTextSize(TypedValue.COMPLEX_UNIT_PX, (it * 1.35f))
         }
@@ -45,6 +44,7 @@ class GeneratorFragment : Fragment(){
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        AnalyticsHelper.sendEvent(AnalyticsEvent.GENERATOR_OPENED)
         (activity as MainActivity).showBottomBar()
     }
 }

--- a/app/src/main/java/com/tnco/runar/ui/fragment/GeneratorMagicRune.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/GeneratorMagicRune.kt
@@ -1,4 +1,4 @@
-package com.tnco.runar.ui.fragments
+package com.tnco.runar.ui.fragment
 
 import android.content.Intent
 import android.net.Uri
@@ -13,9 +13,12 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.tnco.runar.R
+import com.tnco.runar.analytics.AnalyticsHelper
+import com.tnco.runar.enums.AnalyticsEvent
 import com.tnco.runar.feature.MusicController
 import com.tnco.runar.ui.activity.MainActivity
 import com.tnco.runar.ui.viewmodel.MainViewModel
+import com.tnco.runar.util.AnalyticsConstants
 import kotlinx.coroutines.delay
 
 class GeneratorMagicRune : Fragment() {
@@ -47,6 +50,11 @@ class GeneratorMagicRune : Fragment() {
         sendLink = view.findViewById(R.id.generator_description_button_frame)
         progressBarAction()
         sendLink.setOnClickListener {
+            AnalyticsHelper.sendEvent(
+                AnalyticsEvent.MUSIC_LINK_OPENED,
+                Pair(AnalyticsConstants.GROUP_NAME, textGroupName.text.toString()),
+                Pair(AnalyticsConstants.TRACK_NAME, textSongName.text.toString())
+            )
             val uri = Uri.parse(link)
             val intent = Intent(Intent.ACTION_VIEW, uri)
             startActivity(intent)
@@ -61,13 +69,13 @@ class GeneratorMagicRune : Fragment() {
                 delay(70)
                 when (MusicController.currentSongPos) {
                     2 -> {
-                        link ="https://lyod1.bandcamp.com/releases"
+                        link = "https://lyod1.bandcamp.com/releases"
                         textGroupName.text = getString(R.string.group1)
                         textSongName.text = getString(R.string.track1_1)
                         imageGroup.setImageResource(R.drawable.led_image)
                     }
                     3 -> {
-                        link ="https://lyod1.bandcamp.com/releases"
+                        link = "https://lyod1.bandcamp.com/releases"
                         textGroupName.text = getString(R.string.group1)
                         textSongName.text = getString(R.string.track1_2)
                         imageGroup.setImageResource(R.drawable.led_image)

--- a/app/src/main/java/com/tnco/runar/ui/fragment/GeneratorStartFragment.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/GeneratorStartFragment.kt
@@ -13,14 +13,13 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import coil.load
 import com.tnco.runar.R
-
+import com.tnco.runar.analytics.AnalyticsHelper
 import com.tnco.runar.databinding.FragmentGeneratorStartBinding
+import com.tnco.runar.enums.AnalyticsEvent
 import com.tnco.runar.model.RunesItemsModel
 import com.tnco.runar.ui.adapter.RunesGeneratorAdapter
 import com.tnco.runar.util.observeOnce
-
 import com.tnco.runar.ui.activity.MainActivity
-import com.tnco.runar.ui.fragments.GeneratorMagicRune
 import com.tnco.runar.ui.viewmodel.MainViewModel
 import kotlinx.coroutines.launch
 import java.util.*
@@ -45,7 +44,7 @@ class GeneratorStartFragment : Fragment() {
             activity?.onBackPressed()
         }
         mViewModel = ViewModelProvider(requireActivity()).get(MainViewModel::class.java)
-
+        AnalyticsHelper.sendEvent(AnalyticsEvent.GENERATOR_PATTERN_SELECTED)
         setupRecyclerView()
         readDatabase()
 
@@ -160,7 +159,7 @@ class GeneratorStartFragment : Fragment() {
 
 
     private fun randomRunes() {
-
+        AnalyticsHelper.sendEvent(AnalyticsEvent.GENERATOR_PATTERN_RANDOM_RUNES)
         val count = (1..3).random()
         listId.clear()
         for (i in 0 until count) {
@@ -169,7 +168,7 @@ class GeneratorStartFragment : Fragment() {
         }
         listId.sort()
         var idsString = ""
-        when(count){
+        when (count) {
             1 -> {
                 idsString = listId[0].toString()
             }
@@ -195,7 +194,7 @@ class GeneratorStartFragment : Fragment() {
         var idsString = ""
         val count = listId.count()
 
-        when(count){
+        when (count) {
             1 -> {
                 idsString = listId[0].toString()
             }

--- a/app/src/main/java/com/tnco/runar/ui/fragment/RunePatternGenerator.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/RunePatternGenerator.kt
@@ -1,4 +1,4 @@
-package com.tnco.runar.ui.fragments
+package com.tnco.runar.ui.fragment
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -10,10 +10,12 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.tnco.runar.R
+import com.tnco.runar.analytics.AnalyticsHelper
+import com.tnco.runar.enums.AnalyticsEvent
 import com.tnco.runar.ui.activity.MainActivity
 import com.tnco.runar.ui.viewmodel.MainViewModel
 
-class RunePatternGenerator: Fragment() {
+class RunePatternGenerator : Fragment() {
     private lateinit var viewModel: MainViewModel
     lateinit var sendBtn: TextView
     lateinit var nextType: TextView
@@ -31,20 +33,20 @@ class RunePatternGenerator: Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
+        AnalyticsHelper.sendEvent(AnalyticsEvent.GENERATOR_PATTERN_CREATED)
         (activity as MainActivity).hideBottomBar()
 
         imgRune = view.findViewById(R.id.imageRune)
         nextType = view.findViewById(R.id.next_type)
 
         viewModel.runeImagesReady.observe(viewLifecycleOwner, Observer {
-            if (it && !firstImageWasReady && viewModel.runesImages.size > 0){
+            if (it && !firstImageWasReady && viewModel.runesImages.size > 0) {
                 imgRune?.setImageBitmap(viewModel.runesImages[0])
                 nextType?.visibility = View.VISIBLE
             }
         })
 
-        if(viewModel.runesImages.size > 0){
+        if (viewModel.runesImages.size > 0) {
             imgRune?.setImageBitmap(viewModel.runesImages[0])
             nextType?.visibility = View.VISIBLE
             firstImageWasReady = true
@@ -56,10 +58,11 @@ class RunePatternGenerator: Fragment() {
 
 
         nextType.setOnClickListener {
-           viewModel.selectedRuneIndex += 1
-           if (viewModel.selectedRuneIndex > viewModel.runesImages.size - 1){
-               viewModel.selectedRuneIndex = 0
-           }
+            AnalyticsHelper.sendEvent(AnalyticsEvent.GENERATOR_PATTERN_NEW_TYPE)
+            viewModel.selectedRuneIndex += 1
+            if (viewModel.selectedRuneIndex > viewModel.runesImages.size - 1) {
+                viewModel.selectedRuneIndex = 0
+            }
             imgRune.setImageBitmap(viewModel.runesImages[viewModel.selectedRuneIndex])
         }
 


### PR DESCRIPTION
Добавил фаирбэйз ивентов для аналитики на разных экранах с генератором.

    GENERATOR_OPENED("generator_opened"),
    GENERATOR_PATTERN_SELECTED("generator_pattern_selected"),
    GENERATOR_PATTERN_RANDOM_RUNES("generator_pattern_random_runes"),
    GENERATOR_PATTERN_CREATED("generator_pattern_created"),
    GENERATOR_PATTERN_NEW_TYPE("generator_pattern_new_type"),
    GENERATOR_PATTERN_SELECTION_BACKGROUND("generator_pattern_selection_background"),
    GENERATOR_PATTERN_SAVED("generator_pattern_saved"),
    GENERATOR_PATTERN_SHARED("generator_pattern_shared"),
    MUSIC_LINK_OPENED("music_link_opened")

Отрефакторил кодстайл нажав ctrl+alt+L и поменял некорректные названия пэкиджей 