### PR TITLE
RUN-121 / Incorrect rune-title style on generator rune choose page

### DIFF
--- a/app/src/main/res/layout/fragment_generator_start.xml
+++ b/app/src/main/res/layout/fragment_generator_start.xml
@@ -136,7 +136,6 @@
             android:text="1"
             android:textColor="@color/rune_number_color_deselected"
             android:textSize="50sp"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -145,7 +144,6 @@
             android:layout_width="58dp"
             android:layout_height="76dp"
             android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -159,8 +157,7 @@
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@+id/rune_1"
-            app:layout_constraintStart_toStartOf="@id/rune_1"
-            app:layout_constraintTop_toBottomOf="@id/rune_1" />
+            app:layout_constraintStart_toStartOf="@id/rune_1" />
 
         <TextView
             android:id="@+id/tv_rune_2"
@@ -172,7 +169,6 @@
             android:text="2"
             android:textColor="@color/rune_number_color_deselected"
             android:textSize="50sp"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/tv_rune_3"
             app:layout_constraintStart_toEndOf="@+id/tv_rune_1"
             app:layout_constraintTop_toTopOf="parent" />
@@ -182,7 +178,6 @@
             android:layout_width="58dp"
             android:layout_height="76dp"
             android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/rune_3"
             app:layout_constraintStart_toEndOf="@+id/rune_1"
             app:layout_constraintTop_toTopOf="parent" />
@@ -197,8 +192,7 @@
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@id/rune_2"
-            app:layout_constraintStart_toStartOf="@id/rune_2"
-            app:layout_constraintTop_toBottomOf="@id/rune_2" />
+            app:layout_constraintStart_toStartOf="@id/rune_2" />
 
         <TextView
             android:id="@+id/tv_rune_3"
@@ -210,7 +204,6 @@
             android:text="3"
             android:textColor="@color/rune_number_color_deselected"
             android:textSize="50sp"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -219,7 +212,6 @@
             android:layout_width="58dp"
             android:layout_height="76dp"
             android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -233,8 +225,7 @@
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@id/rune_3"
-            app:layout_constraintStart_toStartOf="@id/rune_3"
-            app:layout_constraintTop_toBottomOf="@id/rune_3" />
+            app:layout_constraintStart_toStartOf="@id/rune_3" />
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Исправил перекрытие текста названия руны в генераторе на маленьких устройствах

Было:
![image](https://user-images.githubusercontent.com/109814366/194376953-62ccb206-ad40-45dd-ad82-cc6852c2e5ea.png)


Стало:
![image](https://user-images.githubusercontent.com/109814366/194376509-7ac9446a-a065-4608-91ff-9b043a8b8215.png)
