### PR TITLE
Fixed incorrect translation behavior of Library tab

### DIFF
--- a/app/src/main/java/com/tnco/runar/ui/fragment/LibraryFragment.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/LibraryFragment.kt
@@ -81,6 +81,11 @@ class LibraryFragment : Fragment() {
         }
         return view
     }
+
+    override fun onDetach() {
+        super.onDetach()
+        viewModelStore.clear()
+    }
 }
 
 @ExperimentalPagerApi


### PR DESCRIPTION
Navigation in the library tab is implemented through the viewModel. This is unnatural way to navigation through Android. Therefore, you must clear the viewModel after exiting the fragment.
