### PR TITLE
run-214: make bottom bar translucent

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -94,7 +94,7 @@
     <color name="helper_text_color">#FFFFFF</color>
     <color name="single_rune_text_color">#D2C4AD</color>
 
-    <color name="bottom_bar_background">#1D1D1D</color>
+    <color name="bottom_bar_background">#CE1D1D1D</color>
 
     <color name="onboard_skip_color">#B3FFFFFF</color>
 


### PR DESCRIPTION
Сделала навигейшн бар согласно фигме полупрозрачным.

![аыав](https://user-images.githubusercontent.com/90146704/203105776-d5894379-2cb4-4c7c-b006-e2ba0706d6ab.jpg)

