### PR TITLE
increase compileSdkVersion 32 to 33

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     implementation "com.google.accompanist:accompanist-flowlayout:0.25.1"
     // Tooling support (Previews, etc.)
     debugImplementation  "androidx.compose.ui:ui-tooling:$compose_version"
+    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     // Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
     implementation "androidx.compose.foundation:foundation:$compose_version"
     // Material Design

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
@@ -57,6 +57,7 @@ dependencies {
     def room_version = '2.4.2'
     def preference_version = '1.2.0'
     def retrofit_version = "2.9.0"
+    def compose_version = "1.3.0-alpha01"
 
     //retrofit
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
@@ -90,24 +91,24 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-common-java8:2.5.0'
 
     //compose
-    implementation 'androidx.compose.ui:ui:1.3.0-alpha01'
+    implementation "androidx.compose.ui:ui:$compose_version"
     implementation "com.google.accompanist:accompanist-flowlayout:0.25.1"
     // Tooling support (Previews, etc.)
-    implementation 'androidx.compose.ui:ui-tooling:1.3.0-alpha01'
+    debugImplementation  "androidx.compose.ui:ui-tooling:$compose_version"
     // Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
-    implementation 'androidx.compose.foundation:foundation:1.3.0-alpha01'
+    implementation "androidx.compose.foundation:foundation:$compose_version"
     // Material Design
-    implementation 'androidx.compose.material:material:1.3.0-alpha01'
+    implementation "androidx.compose.material:material:$compose_version"
     // Material design icons
-    implementation 'androidx.compose.material:material-icons-core:1.3.0-alpha01'
-    implementation 'androidx.compose.material:material-icons-extended:1.3.0-alpha01'
+    implementation "androidx.compose.material:material-icons-core:$compose_version"
+    implementation "androidx.compose.material:material-icons-extended:$compose_version"
     // Integration with activities
-    implementation 'androidx.activity:activity-compose:1.5.0'
+    implementation 'androidx.activity:activity-compose:1.7.0-alpha02'
     // Integration with ViewModels
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.0-alpha01'
     // Integration with observables
-    implementation 'androidx.compose.runtime:runtime-livedata:1.3.0-alpha01'
-    implementation 'androidx.compose.runtime:runtime-rxjava2:1.3.0-alpha01'
+    implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
+    implementation "androidx.compose.runtime:runtime-rxjava2:$compose_version"
 
     //coil
     implementation("io.coil-kt:coil:2.2.0")


### PR DESCRIPTION
## Описание 📝
Compose preview didn't work. This issue was related to androidx.activity:activity-compose version. An actual version solved this problem but required updating compileSdkVersion to 33.