### PR TITLE
Expanding the sensitive area of pressing the arrow (Part 2)

### DIFF
--- a/app/src/main/res/layout-hdpi/fragment_layout_interpretation.xml
+++ b/app/src/main/res/layout-hdpi/fragment_layout_interpretation.xml
@@ -55,7 +55,7 @@
                         android:elevation="6dp"
                         android:scaleType="fitXY"
                         android:src="@drawable/description_top_background"
-                        app:layout_constraintDimensionRatio="H,3.5:1"
+                        app:layout_constraintDimensionRatio="H,2.5:1"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
@@ -131,7 +131,7 @@
                         app:layout_constraintStart_toStartOf="@id/rune_ausf_start_guideline"
                         app:layout_constraintTop_toBottomOf="@id/rune_position_frame" />
 
-                    <ScrollView
+                    <androidx.core.widget.NestedScrollView
                         android:id="@+id/rune_description_scroll"
                         android:layout_width="0dp"
                         android:layout_height="0dp"
@@ -149,7 +149,7 @@
                             android:lineSpacingMultiplier="1.35"
                             android:textColor="@color/auf_text_color"
                             android:paddingBottom="40dp"/>
-                    </ScrollView>
+                    </androidx.core.widget.NestedScrollView>
 
                     <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/rune_description_bottom_background"
@@ -160,40 +160,41 @@
                         android:elevation="6dp"
                         android:scaleType="centerCrop"
                         app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintDimensionRatio="H,1:1"
+                        app:layout_constraintDimensionRatio="H,5:1"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent" />
 
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/bottom_runes_nav_bar"
                         android:layout_width="match_parent"
-                        android:layout_height="0dp"
+                        android:layout_height="wrap_content"
                         android:elevation="7dp"
                         app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintDimensionRatio="H,10:1"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent">
 
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/left_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_left_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toEndOf="@id/left_arrow_end_guideline"
-                            app:layout_constraintStart_toStartOf="@id/left_arrow_start_guideline"
+                            app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
 
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/right_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_right_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toEndOf="@id/right_arrow_end_guideline"
-                            app:layout_constraintStart_toStartOf="@id/right_arrow_start_guideline"
+                            app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
 
                         <androidx.constraintlayout.widget.Guideline

--- a/app/src/main/res/layout-hdpi/fragment_layout_interpretation_fav.xml
+++ b/app/src/main/res/layout-hdpi/fragment_layout_interpretation_fav.xml
@@ -55,7 +55,7 @@
                         app:layout_constraintTop_toTopOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintDimensionRatio="H,3.5:1"/>
+                        app:layout_constraintDimensionRatio="H,2.5:1"/>
 
                     <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/exit_button"
@@ -123,7 +123,7 @@
                         app:layout_constraintTop_toBottomOf="@id/rune_position_frame"
                         app:layout_constraintStart_toStartOf="@id/rune_ausf_start_guideline"
                         app:layout_constraintEnd_toEndOf="@id/rune_ausf_end_guideline"/>
-                    <ScrollView
+                    <androidx.core.widget.NestedScrollView
                         android:id="@+id/rune_description_scroll"
                         android:layout_width="0dp"
                         android:layout_height="0dp"
@@ -140,7 +140,7 @@
                             android:lineSpacingMultiplier="1.35"
                             android:textColor="@color/auf_text_color"
                             android:paddingBottom="40dp"/>
-                    </ScrollView>
+                    </androidx.core.widget.NestedScrollView>
                     <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/rune_description_bottom_background"
                         android:layout_width="0dp"
@@ -155,32 +155,33 @@
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/bottom_runes_nav_bar"
                         android:layout_width="match_parent"
-                        android:layout_height="0dp"
+                        android:layout_height="wrap_content"
                         android:elevation="7dp"
-                        app:layout_constraintDimensionRatio="H,10:1"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent">
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/left_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_left_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintTop_toTopOf="parent"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="@id/left_arrow_start_guideline"
-                            app:layout_constraintEnd_toEndOf="@id/left_arrow_end_guideline"/>
+                            app:layout_constraintStart_toStartOf="parent"/>
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/right_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_right_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintTop_toTopOf="parent"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="@id/right_arrow_start_guideline"
-                            app:layout_constraintEnd_toEndOf="@id/right_arrow_end_guideline"/>
+                            app:layout_constraintEnd_toEndOf="parent"/>
                         <androidx.constraintlayout.widget.Guideline
                             android:id="@+id/bottom_runes_nav_center"
                             android:layout_width="wrap_content"

--- a/app/src/main/res/layout-sw600dp/fragment_layout_interpretation.xml
+++ b/app/src/main/res/layout-sw600dp/fragment_layout_interpretation.xml
@@ -131,7 +131,7 @@
                         app:layout_constraintStart_toStartOf="@id/rune_ausf_start_guideline"
                         app:layout_constraintTop_toBottomOf="@id/rune_position_frame" />
 
-                    <ScrollView
+                    <androidx.core.widget.NestedScrollView
                         android:id="@+id/rune_description_scroll"
                         android:layout_width="0dp"
                         android:layout_height="0dp"
@@ -149,7 +149,7 @@
                             android:lineSpacingMultiplier="1.35"
                             android:textColor="@color/auf_text_color"
                             android:paddingBottom="40dp"/>
-                    </ScrollView>
+                    </androidx.core.widget.NestedScrollView>
 
                     <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/rune_description_bottom_background"
@@ -159,40 +159,41 @@
                         android:elevation="6dp"
                         android:scaleType="centerCrop"
                         app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintDimensionRatio="H,6:1"
+                        app:layout_constraintDimensionRatio="H,5:1"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent" />
 
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/bottom_runes_nav_bar"
                         android:layout_width="match_parent"
-                        android:layout_height="0dp"
+                        android:layout_height="wrap_content"
                         android:elevation="7dp"
                         app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintDimensionRatio="H,10:1"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent">
 
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/left_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_left_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toEndOf="@id/left_arrow_end_guideline"
-                            app:layout_constraintStart_toStartOf="@id/left_arrow_start_guideline"
+                            app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
 
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/right_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_right_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toEndOf="@id/right_arrow_end_guideline"
-                            app:layout_constraintStart_toStartOf="@id/right_arrow_start_guideline"
+                            app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
 
                         <androidx.constraintlayout.widget.Guideline

--- a/app/src/main/res/layout-sw600dp/fragment_layout_interpretation_fav.xml
+++ b/app/src/main/res/layout-sw600dp/fragment_layout_interpretation_fav.xml
@@ -123,7 +123,7 @@
                         app:layout_constraintTop_toBottomOf="@id/rune_position_frame"
                         app:layout_constraintStart_toStartOf="@id/rune_ausf_start_guideline"
                         app:layout_constraintEnd_toEndOf="@id/rune_ausf_end_guideline"/>
-                    <ScrollView
+                    <androidx.core.widget.NestedScrollView
                         android:id="@+id/rune_description_scroll"
                         android:layout_width="0dp"
                         android:layout_height="0dp"
@@ -140,7 +140,7 @@
                             android:lineSpacingMultiplier="1.35"
                             android:textColor="@color/auf_text_color"
                             android:paddingBottom="40dp"/>
-                    </ScrollView>
+                    </androidx.core.widget.NestedScrollView>
                     <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/rune_description_bottom_background"
                         android:layout_width="0dp"
@@ -155,32 +155,33 @@
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/bottom_runes_nav_bar"
                         android:layout_width="match_parent"
-                        android:layout_height="0dp"
+                        android:layout_height="wrap_content"
                         android:elevation="7dp"
-                        app:layout_constraintDimensionRatio="H,10:1"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent">
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/left_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_left_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintTop_toTopOf="parent"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="@id/left_arrow_start_guideline"
-                            app:layout_constraintEnd_toEndOf="@id/left_arrow_end_guideline"/>
+                            app:layout_constraintStart_toStartOf="parent"/>
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/right_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_right_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintTop_toTopOf="parent"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="@id/right_arrow_start_guideline"
-                            app:layout_constraintEnd_toEndOf="@id/right_arrow_end_guideline"/>
+                            app:layout_constraintEnd_toEndOf="parent"/>
                         <androidx.constraintlayout.widget.Guideline
                             android:id="@+id/bottom_runes_nav_center"
                             android:layout_width="wrap_content"

--- a/app/src/main/res/layout-sw720dp/fragment_layout_interpretation.xml
+++ b/app/src/main/res/layout-sw720dp/fragment_layout_interpretation.xml
@@ -131,7 +131,7 @@
                         app:layout_constraintStart_toStartOf="@id/rune_ausf_start_guideline"
                         app:layout_constraintTop_toBottomOf="@id/rune_position_frame" />
 
-                    <ScrollView
+                    <androidx.core.widget.NestedScrollView
                         android:id="@+id/rune_description_scroll"
                         android:layout_width="0dp"
                         android:layout_height="0dp"
@@ -149,7 +149,7 @@
                             android:lineSpacingMultiplier="1.35"
                             android:textColor="@color/auf_text_color"
                             android:paddingBottom="40dp"/>
-                    </ScrollView>
+                    </androidx.core.widget.NestedScrollView>
 
                     <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/rune_description_bottom_background"
@@ -159,40 +159,41 @@
                         android:elevation="6dp"
                         android:scaleType="centerCrop"
                         app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintDimensionRatio="H,6:1"
+                        app:layout_constraintDimensionRatio="H,5:1"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent" />
 
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/bottom_runes_nav_bar"
                         android:layout_width="match_parent"
-                        android:layout_height="0dp"
+                        android:layout_height="wrap_content"
                         android:elevation="7dp"
                         app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintDimensionRatio="H,10:1"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent">
 
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/left_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_left_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toEndOf="@id/left_arrow_end_guideline"
-                            app:layout_constraintStart_toStartOf="@id/left_arrow_start_guideline"
+                            app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
 
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/right_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_right_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toEndOf="@id/right_arrow_end_guideline"
-                            app:layout_constraintStart_toStartOf="@id/right_arrow_start_guideline"
+                            app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
 
                         <androidx.constraintlayout.widget.Guideline

--- a/app/src/main/res/layout-sw720dp/fragment_layout_interpretation_fav.xml
+++ b/app/src/main/res/layout-sw720dp/fragment_layout_interpretation_fav.xml
@@ -123,7 +123,7 @@
                         app:layout_constraintTop_toBottomOf="@id/rune_position_frame"
                         app:layout_constraintStart_toStartOf="@id/rune_ausf_start_guideline"
                         app:layout_constraintEnd_toEndOf="@id/rune_ausf_end_guideline"/>
-                    <ScrollView
+                    <androidx.core.widget.NestedScrollView
                         android:id="@+id/rune_description_scroll"
                         android:layout_width="0dp"
                         android:layout_height="0dp"
@@ -140,7 +140,7 @@
                             android:lineSpacingMultiplier="1.35"
                             android:textColor="@color/auf_text_color"
                             android:paddingBottom="40dp"/>
-                    </ScrollView>
+                    </androidx.core.widget.NestedScrollView>
                     <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/rune_description_bottom_background"
                         android:layout_width="0dp"
@@ -155,32 +155,33 @@
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/bottom_runes_nav_bar"
                         android:layout_width="match_parent"
-                        android:layout_height="0dp"
+                        android:layout_height="wrap_content"
                         android:elevation="7dp"
-                        app:layout_constraintDimensionRatio="H,10:1"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent">
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/left_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_left_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintTop_toTopOf="parent"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="@id/left_arrow_start_guideline"
-                            app:layout_constraintEnd_toEndOf="@id/left_arrow_end_guideline"/>
+                            app:layout_constraintStart_toStartOf="parent"/>
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/right_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_right_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintTop_toTopOf="parent"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="@id/right_arrow_start_guideline"
-                            app:layout_constraintEnd_toEndOf="@id/right_arrow_end_guideline"/>
+                            app:layout_constraintEnd_toEndOf="parent"/>
                         <androidx.constraintlayout.widget.Guideline
                             android:id="@+id/bottom_runes_nav_center"
                             android:layout_width="wrap_content"

--- a/app/src/main/res/layout-xhdpi/fragment_layout_interpretation.xml
+++ b/app/src/main/res/layout-xhdpi/fragment_layout_interpretation.xml
@@ -55,7 +55,7 @@
                         android:elevation="6dp"
                         android:scaleType="fitXY"
                         android:src="@drawable/description_top_background"
-                        app:layout_constraintDimensionRatio="H,3.5:1"
+                        app:layout_constraintDimensionRatio="H,2.5:1"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
@@ -131,7 +131,7 @@
                         app:layout_constraintStart_toStartOf="@id/rune_ausf_start_guideline"
                         app:layout_constraintTop_toBottomOf="@id/rune_position_frame" />
 
-                    <ScrollView
+                    <androidx.core.widget.NestedScrollView
                         android:id="@+id/rune_description_scroll"
                         android:layout_width="0dp"
                         android:layout_height="0dp"
@@ -149,7 +149,7 @@
                             android:lineSpacingMultiplier="1.35"
                             android:textColor="@color/auf_text_color"
                             android:paddingBottom="40dp"/>
-                    </ScrollView>
+                    </androidx.core.widget.NestedScrollView>
 
                     <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/rune_description_bottom_background"
@@ -159,40 +159,41 @@
                         android:elevation="6dp"
                         android:scaleType="centerCrop"
                         app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintDimensionRatio="H,6:1"
+                        app:layout_constraintDimensionRatio="H,5:1"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent" />
 
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/bottom_runes_nav_bar"
                         android:layout_width="match_parent"
-                        android:layout_height="0dp"
+                        android:layout_height="wrap_content"
                         android:elevation="7dp"
                         app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintDimensionRatio="H,10:1"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent">
 
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/left_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_left_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toEndOf="@id/left_arrow_end_guideline"
-                            app:layout_constraintStart_toStartOf="@id/left_arrow_start_guideline"
+                            app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
 
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/right_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_right_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toEndOf="@id/right_arrow_end_guideline"
-                            app:layout_constraintStart_toStartOf="@id/right_arrow_start_guideline"
+                            app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
 
                         <androidx.constraintlayout.widget.Guideline

--- a/app/src/main/res/layout-xhdpi/fragment_layout_interpretation_fav.xml
+++ b/app/src/main/res/layout-xhdpi/fragment_layout_interpretation_fav.xml
@@ -55,7 +55,7 @@
                         app:layout_constraintTop_toTopOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintDimensionRatio="H,3.5:1"/>
+                        app:layout_constraintDimensionRatio="H,2.5:1"/>
 
                     <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/exit_button"
@@ -123,7 +123,7 @@
                         app:layout_constraintTop_toBottomOf="@id/rune_position_frame"
                         app:layout_constraintStart_toStartOf="@id/rune_ausf_start_guideline"
                         app:layout_constraintEnd_toEndOf="@id/rune_ausf_end_guideline"/>
-                    <ScrollView
+                    <androidx.core.widget.NestedScrollView
                         android:id="@+id/rune_description_scroll"
                         android:layout_width="0dp"
                         android:layout_height="0dp"
@@ -140,7 +140,7 @@
                             android:lineSpacingMultiplier="1.35"
                             android:textColor="@color/auf_text_color"
                             android:paddingBottom="40dp"/>
-                    </ScrollView>
+                    </androidx.core.widget.NestedScrollView>
                     <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/rune_description_bottom_background"
                         android:layout_width="0dp"
@@ -155,32 +155,33 @@
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/bottom_runes_nav_bar"
                         android:layout_width="match_parent"
-                        android:layout_height="0dp"
+                        android:layout_height="wrap_content"
                         android:elevation="7dp"
-                        app:layout_constraintDimensionRatio="H,10:1"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent">
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/left_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_left_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintTop_toTopOf="parent"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="@id/left_arrow_start_guideline"
-                            app:layout_constraintEnd_toEndOf="@id/left_arrow_end_guideline"/>
+                            app:layout_constraintStart_toStartOf="parent"/>
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/right_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_right_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintTop_toTopOf="parent"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="@id/right_arrow_start_guideline"
-                            app:layout_constraintEnd_toEndOf="@id/right_arrow_end_guideline"/>
+                            app:layout_constraintEnd_toEndOf="parent"/>
                         <androidx.constraintlayout.widget.Guideline
                             android:id="@+id/bottom_runes_nav_center"
                             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_layout_interpretation.xml
+++ b/app/src/main/res/layout/fragment_layout_interpretation.xml
@@ -131,7 +131,7 @@
                         app:layout_constraintStart_toStartOf="@id/rune_ausf_start_guideline"
                         app:layout_constraintTop_toBottomOf="@id/rune_position_frame" />
 
-                    <ScrollView
+                    <androidx.core.widget.NestedScrollView
                         android:id="@+id/rune_description_scroll"
                         android:layout_width="0dp"
                         android:layout_height="0dp"
@@ -149,7 +149,7 @@
                             android:lineSpacingMultiplier="1.35"
                             android:textColor="@color/auf_text_color"
                             android:paddingBottom="40dp"/>
-                    </ScrollView>
+                    </androidx.core.widget.NestedScrollView>
 
                     <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/rune_description_bottom_background"
@@ -159,7 +159,7 @@
                         android:elevation="6dp"
                         android:scaleType="centerCrop"
                         app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintDimensionRatio="H,4:1"
+                        app:layout_constraintDimensionRatio="H,5:1"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent" />
 
@@ -168,30 +168,30 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:elevation="7dp"
-                        android:paddingStart="12dp"
-                        android:paddingEnd="12dp"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent">
 
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/left_arrow"
-                            android:layout_width="48dp"
-                            android:layout_height="48dp"
-                            android:padding="12dp"
-                            android:adjustViewBounds="true"
+                            android:layout_width="0dp"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_left_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
 
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/right_arrow"
-                            android:layout_width="48dp"
-                            android:layout_height="48dp"
-                            android:padding="12dp"
-                            android:adjustViewBounds="true"
+                            android:layout_width="0dp"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_right_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/fragment_layout_interpretation_fav.xml
+++ b/app/src/main/res/layout/fragment_layout_interpretation_fav.xml
@@ -123,7 +123,7 @@
                         app:layout_constraintTop_toBottomOf="@id/rune_position_frame"
                         app:layout_constraintStart_toStartOf="@id/rune_ausf_start_guideline"
                         app:layout_constraintEnd_toEndOf="@id/rune_ausf_end_guideline"/>
-                    <ScrollView
+                    <androidx.core.widget.NestedScrollView
                         android:id="@+id/rune_description_scroll"
                         android:layout_width="0dp"
                         android:layout_height="0dp"
@@ -140,7 +140,7 @@
                             android:lineSpacingMultiplier="1.35"
                             android:textColor="@color/auf_text_color"
                             android:paddingBottom="40dp"/>
-                    </ScrollView>
+                    </androidx.core.widget.NestedScrollView>
                     <androidx.appcompat.widget.AppCompatImageView
                         android:id="@+id/rune_description_bottom_background"
                         android:layout_width="0dp"
@@ -155,32 +155,33 @@
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/bottom_runes_nav_bar"
                         android:layout_width="match_parent"
-                        android:layout_height="0dp"
+                        android:layout_height="wrap_content"
                         android:elevation="7dp"
-                        app:layout_constraintDimensionRatio="H,10:1"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent">
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/left_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_left_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintTop_toTopOf="parent"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="@id/left_arrow_start_guideline"
-                            app:layout_constraintEnd_toEndOf="@id/left_arrow_end_guideline"/>
+                            app:layout_constraintStart_toStartOf="parent" />
                         <androidx.appcompat.widget.AppCompatImageView
                             android:id="@+id/right_arrow"
                             android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:adjustViewBounds="true"
+                            android:layout_height="0dp"
+                            android:scaleType="centerInside"
                             android:src="@drawable/ic_runes_nav_right_arrow"
+                            app:layout_constraintWidth_percent="0.2"
+                            app:layout_constraintDimensionRatio="1.5"
                             app:layout_constraintTop_toTopOf="parent"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="@id/right_arrow_start_guideline"
-                            app:layout_constraintEnd_toEndOf="@id/right_arrow_end_guideline"/>
+                            app:layout_constraintEnd_toEndOf="parent"/>
                         <androidx.constraintlayout.widget.Guideline
                             android:id="@+id/bottom_runes_nav_center"
                             android:layout_width="wrap_content"


### PR DESCRIPTION
Expended the size of the sensitive zone in Runic Draws and Favorites.


The size of the sensitive area around the arrow now looks like:

![image](https://user-images.githubusercontent.com/43334039/207241974-37bd2b67-694e-4676-8d3a-e81f99011cc9.png)
