### PR TITLE
New design audio rows

### DIFF
--- a/app/src/main/java/com/tnco/runar/feature_audio_fairytailes/presentation/player/AudioScreen.kt
+++ b/app/src/main/java/com/tnco/runar/feature_audio_fairytailes/presentation/player/AudioScreen.kt
@@ -9,7 +9,12 @@ import com.tnco.runar.feature_audio_fairytailes.presentation.player.components.A
 
 @Composable
 fun AudioScreen() {
-    AudioFairyTalesList(audioFairyTales = emptyMap())
+    val audioFairyTales: Map<String, List<String>> = mapOf(
+        "Books" to listOf("To Kill a Mockingbird", "Lord of the Flies", "Wuthering Heights"),
+        "Norwegian Fairytales" to listOf("The Fisherman and the Draug", "The Giant Who Had No Heart in His Body", "Farmer Weatherbeard", "The King's Hares", "Minnikin", "The Master Maid"),
+        "Christmas Music" to listOf("All I Want For Christmas Is You", "Rockin' Around The Christmas Tree", "Jingle Bell Rock", "A Holly Jolly Christmas", "Anti-Hero", "Unholy", "Superhero", "Last Christmas", "Rich Flex"),
+    )
+    AudioFairyTalesList(audioFairyTales = audioFairyTales)
 }
 
 @Composable

--- a/app/src/main/java/com/tnco/runar/feature_audio_fairytailes/presentation/player/components/Widgets.kt
+++ b/app/src/main/java/com/tnco/runar/feature_audio_fairytailes/presentation/player/components/Widgets.kt
@@ -9,8 +9,8 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LibraryMusic
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
@@ -24,7 +24,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
@@ -59,8 +58,10 @@ internal fun AudioHeader(
                     color = colorResource(id = R.color.audio_header_text),
                     fontSize = 16.sp,
                     fontFamily = FontFamily(Font(R.font.roboto_regular)),
-                    lineHeight = 24.em
-                )
+                    lineHeight = 24.sp
+                ),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
             Divider(
                 color = colorResource(id = R.color.audio_divider),
@@ -82,7 +83,7 @@ internal fun AudioDetailRow(
             .padding(
                 start = 16.dp,
                 end = 16.dp,
-                top = 8.dp
+                top = 12.dp
             ),
         color = Color.Transparent
     ) {
@@ -92,9 +93,9 @@ internal fun AudioDetailRow(
             ConstraintLayout(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 8.dp)
+                    .padding(bottom = 12.dp)
             ) {
-                val (audioImage, audioText, audioTime, audioImageMore) = createRefs()
+                val (audioImage, audioText, audioTime) = createRefs()
 
                 Image(
                     painter = rememberVectorPainter(image = image),
@@ -105,7 +106,7 @@ internal fun AudioDetailRow(
                             start.linkTo(parent.start)
                             bottom.linkTo(parent.bottom)
                         }
-                        .size(40.dp)
+                        .size(64.dp)
                         .border(
                             1.dp,
                             colorResource(id = R.color.audio_border_image),
@@ -114,32 +115,38 @@ internal fun AudioDetailRow(
                     colorFilter = ColorFilter.tint(Color.White),
                     contentScale = ContentScale.Fit
                 )
-                Text(
+                Box(
                     modifier = Modifier
                         .constrainAs(audioText) {
                             width = Dimension.fillToConstraints
-                            top.linkTo(parent.top)
+                            height = Dimension.fillToConstraints
+                            top.linkTo(audioImage.top)
+                            bottom.linkTo(audioImage.bottom)
                             start.linkTo(audioImage.end, 16.dp)
                             end.linkTo(audioTime.start, 16.dp)
                         },
-                    text = name,
-                    style = TextStyle(
-                        color = colorResource(id = R.color.audio_name_text),
-                        fontSize = 16.sp,
-                        fontFamily = FontFamily(
-                            Font(R.font.roboto_regular)
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    Text(
+                        text = name,
+                        style = TextStyle(
+                            color = colorResource(id = R.color.audio_name_text),
+                            fontSize = 16.sp,
+                            fontFamily = FontFamily(
+                                Font(R.font.roboto_regular)
+                            ),
+                            lineHeight = 24.sp
                         ),
-                        lineHeight = 24.em
-                    ),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
                 Text(
                     modifier = Modifier
                         .constrainAs(audioTime) {
                             top.linkTo(parent.top)
                             bottom.linkTo(parent.bottom)
-                            end.linkTo(audioImageMore.start, 16.dp)
+                            end.linkTo(parent.end, 16.dp)
                         },
                     text = time,
                     style = TextStyle(
@@ -148,26 +155,14 @@ internal fun AudioDetailRow(
                         fontFamily = FontFamily(
                             Font(R.font.roboto_regular)
                         ),
-                        lineHeight = 24.em
+                        lineHeight = 24.sp
                     )
-                )
-                Image(
-                    painter = rememberVectorPainter(image = Icons.Filled.MoreVert),
-                    contentDescription = "Image More",
-                    modifier = Modifier
-                        .constrainAs(audioImageMore) {
-                            top.linkTo(parent.top)
-                            end.linkTo(parent.end)
-                            bottom.linkTo(parent.bottom)
-                        }
-                        .size(24.dp),
-                    colorFilter = ColorFilter.tint(colorResource(id = R.color.audio_image_more_tint))
                 )
             }
             Divider(
                 modifier = Modifier
                     .padding(
-                        start = 56.dp
+                        start = 80.dp
                     ),
                 color = colorResource(id = R.color.audio_divider),
                 thickness = 0.5.dp

--- a/app/src/main/java/com/tnco/runar/ui/fragment/LibraryTabsCompose.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/LibraryTabsCompose.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
@@ -22,6 +21,7 @@ import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.pagerTabIndicatorOffset
 import com.tnco.runar.R
+import com.tnco.runar.feature_audio_fairytailes.presentation.player.AudioScreen
 import kotlinx.coroutines.launch
 
 @ExperimentalPagerApi
@@ -36,7 +36,10 @@ internal fun TabScreen(pagerState: PagerState, scrollState: ScrollState, fontSiz
 @ExperimentalPagerApi
 @Composable
 private fun TabsContent(pagerState: PagerState, scrollState: ScrollState) {
-    HorizontalPager(state = pagerState) { page ->
+    HorizontalPager(
+        state = pagerState,
+        verticalAlignment = Alignment.Top
+    ) { page ->
         when (page) {
             0 -> {
                 Column(
@@ -49,16 +52,7 @@ private fun TabsContent(pagerState: PagerState, scrollState: ScrollState) {
                 }
             }
 
-            1 -> {
-                // Audio Library fun will be here
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(text = "Audio", color = Color.White)
-                }
-            }
+            1 -> AudioScreen()
         }
     }
 }


### PR DESCRIPTION
1. Made audio rows higher and delete reduntant items
2. Corrected of Book tab content centering
3. Added fake audio data for testing


![Screenshot_20221221_111545](https://user-images.githubusercontent.com/43334039/208854678-eb304443-c46d-4132-91b1-c4f5407f7f57.png)
![Screenshot_20221221_111556](https://user-images.githubusercontent.com/43334039/208854708-7b6a0ed6-6bf0-4a3e-b0c2-f12f8d0f66e0.png)

