### PR TITLE
RUN-244(Comeback)/ Update strings.xml, fixed toast

### DIFF
--- a/app/src/main/java/com/tnco/runar/ui/fragment/LibraryCompose.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/LibraryCompose.kt
@@ -230,10 +230,6 @@ private fun FirstMenuItem(
                 val painter = rememberAsyncImagePainter(imgLink)
                 val painterState = painter.state
                 val viewModel: LibraryViewModel = viewModel()
-                if(painterState is AsyncImagePainter.State.Error) {
-                    viewModel.updateStateLoad(true)
-                }
-                if (viewModel.errorLoad?.value == null) {
                     Image(
                         painter = painter,
                         contentDescription = null,
@@ -243,12 +239,17 @@ private fun FirstMenuItem(
                             .weight(60f)
                             .fillMaxSize()
                     )
-                } else {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(size = 64.dp),
+                if(painterState is AsyncImagePainter.State.Error) {
+                    viewModel.updateStateLoad(true)
+                }
+                when (true) {
+                    (painterState is AsyncImagePainter.State.Error) ->
+                        CircularProgressIndicator(
+                        modifier = Modifier.offset(x = (-25).dp),
                         color = Color.Gray,
-                        strokeWidth = 6.dp
-                    )
+                        strokeWidth = 6.dp)
+                    (painterState is AsyncImagePainter.State.Success) -> viewModel.updateStateLoad(false)
+                    else -> false
                 }
                 Column(
                     Modifier
@@ -311,6 +312,9 @@ private fun SecondMenuItem(
     imgLink: String,
     clickAction: () -> Unit
 ) {
+    val viewModel: LibraryViewModel = viewModel()
+    viewModel.updateStateLoad(false)
+
     if (imgLink.isEmpty()) {
         Row(
             Modifier
@@ -465,6 +469,8 @@ private fun SecondMenuItem(
 
 @Composable
 private fun ThirdMenuItem(fontSize: Float, text: String, title: String) {
+    val viewModel: LibraryViewModel = viewModel()
+    viewModel.updateStateLoad(false)
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Box(Modifier.aspectRatio(35f))
         Text(

--- a/app/src/main/java/com/tnco/runar/ui/fragment/LibraryFragment.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/LibraryFragment.kt
@@ -15,16 +15,14 @@ import com.tnco.runar.analytics.AnalyticsHelper
 import com.tnco.runar.enums.AnalyticsEvent
 import com.tnco.runar.ui.viewmodel.LibraryViewModel
 import com.tnco.runar.util.observeOnce
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 
 const val audioFeature = true
 private const val WAITING_FOR_IMAGES = 3500L
 
 class LibraryFragment : Fragment() {
     val viewModel: LibraryViewModel by viewModels()
+    private val uiScope = CoroutineScope(Dispatchers.Main)
 
     @ExperimentalPagerApi
     override fun onCreateView(
@@ -38,7 +36,7 @@ class LibraryFragment : Fragment() {
         val noInternet = getString(R.string.internet_conn_error1)
 
         viewModel.isOnline.observeOnce(viewLifecycleOwner) { online ->
-            CoroutineScope(Dispatchers.Main).launch {
+            uiScope.launch {
                 delay(WAITING_FOR_IMAGES)
                 if (!online && viewModel.errorLoad.value == true) {
                     Toast.makeText(
@@ -79,5 +77,10 @@ class LibraryFragment : Fragment() {
     override fun onDetach() {
         super.onDetach()
         viewModelStore.clear()
+    }
+
+    override fun onDestroy() {
+        uiScope.cancel()
+        super.onDestroy()
     }
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -143,6 +143,6 @@
 
     <string name="retry">Повторить</string>
     <string name="internet_conn_error">Пожалуйста, проверьте подключение к сети и повторите попытку</string>
-    <string name="internet_conn_error1">Чтобы видеть изображения, необходимо подключиться к интернету!</string>
+    <string name="internet_conn_error1">Нет доступа к интернету!</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,6 @@
 
     <string name="retry">Retry</string>
     <string name="internet_conn_error">Please check your network connection and try again</string>
-    <string name="internet_conn_error1">You need to be connected to the internet to see Images!</string>
+    <string name="internet_conn_error1">No network connection</string>
 
 </resources>


### PR DESCRIPTION
1. Создал uiScope, что бы закрывать ее когда переходим в другие фрагменты
![2023-01-11_12-29-47](https://user-images.githubusercontent.com/99983028/211757537-73f72a9b-819c-46c4-bd55-0587f837ec72.png)
![2023-01-11_12-29-21](https://user-images.githubusercontent.com/99983028/211757464-36678fc5-83d7-4c95-8c0c-94ff6541e6ae.png)
2. Убрал if у Image, что бы получать painterState-ы. Прогресс индикатор передвинул в when, когда состояне загрузки будет Error. 
![2023-01-11_12-34-07](https://user-images.githubusercontent.com/99983028/211757946-b4cd96fd-c210-4984-b200-218097017b80.png)
3. В функциях через updateStateLoad передавал false, что бы toast не появлялся когда переходим мгновенно в сказки или в руны.
![2023-01-11_12-35-07](https://user-images.githubusercontent.com/99983028/211758632-1f489e64-44f0-4699-96da-40473f1c695c.png)



