### PR TITLE
Changed arrow back color of AudioDetailsScreen's appBar

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -142,7 +142,7 @@
     <color name="audio_divider">#FF292929</color>
     <color name="audio_image_more_tint">#FF6E6E6E</color>
     <color name="audio_top_app_bar">@color/library_top_bar</color>
-    <color name="audio_top_app_bar_header">@color/library_top_bar_header</color>
+    <color name="audio_top_app_bar_header">@color/library_top_bar_fav</color>
     <color name="audio_image_background">#FF1E1E1E</color>
     <color name="audio_play_button">#EFCD93</color>
     <color name="audio_play_panel">@color/audio_border_image</color>


### PR DESCRIPTION
Изменил цвет стрелки в AppBar в соответствии в [Figma](https://www.figma.com/file/UYfFVdzGr7vfvXAk4zMd0t/Runar-app?node-id=6864%3A19044&t=CzoCI3Fr6lorXGQo-0)
![Screenshot_20230119_184424](https://user-images.githubusercontent.com/43334039/213487450-229397e5-23f7-4677-b2e2-0ef4cf323fb1.png)
