### PR TITLE
RUN-223/ (Fixed toast) returned to observeOnce and add delay for loading images

### DIFF
--- a/app/src/main/java/com/tnco/runar/ui/fragment/LibraryFragment.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/LibraryFragment.kt
@@ -16,13 +16,8 @@ import com.tnco.runar.enums.AnalyticsEvent
 import com.tnco.runar.ui.viewmodel.LibraryViewModel
 import com.tnco.runar.util.observeOnce
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 const val audioFeature = true
-const val DELAY_FOR_LOADING = 600L
 
 @AndroidEntryPoint
 class LibraryFragment : Fragment() {
@@ -36,22 +31,6 @@ class LibraryFragment : Fragment() {
     ): View {
         viewModel.getRuneDataFromDB()
         viewModel.analyticsHelper.sendEvent(AnalyticsEvent.LIBRARY_OPENED)
-
-        val noInternet = getString(R.string.internet_conn_error1)
-        val toast = Toast.makeText(requireContext(), noInternet, Toast.LENGTH_SHORT)
-
-        viewModel.isOnline.observeOnce(viewLifecycleOwner) {
-            viewModel.errorLoad.observeOnce(viewLifecycleOwner) {
-                CoroutineScope(Dispatchers.Main).launch {
-                    delay(DELAY_FOR_LOADING)
-                    if (viewModel.isOnline.value == false && viewModel.errorLoad.value == true) {
-                        toast.show()
-                    } else {
-                        toast.cancel()
-                    }
-                }
-            }
-        }
 
         val view = ComposeView(requireContext()).apply {
             setContent {
@@ -78,5 +57,18 @@ class LibraryFragment : Fragment() {
             consumed
         }
         return view
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+
+        val noInternet = getString(R.string.internet_conn_error1)
+        viewModel.isOnline.observeOnce(viewLifecycleOwner) {
+            viewModel.errorLoad.observeOnce(viewLifecycleOwner) {
+                if (viewModel.isOnline.value == false && viewModel.errorLoad.value == true) {
+                    Toast.makeText(requireContext(), noInternet, Toast.LENGTH_LONG).show()
+                }
+            }
+            super.onViewCreated(view, savedInstanceState)
+        }
     }
 }


### PR DESCRIPTION
1. Создал двойную подписку на статус соединения с интернетом и загрузками изображений в меню библиотеки.
2. Добавил задержку показа toast -а.