### PR TITLE
RUN-357 Make the language name display regardless of the current locale

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -56,8 +56,6 @@
 
     <string name="settings_layout">Настройки</string>
     <string name="settings_language">Язык</string>
-    <string name="settings_language_rus">Русский</string>
-    <string name="settings_language_en">English</string>
     <string name="music_txt">Музыка</string>
     <string name="onboarding_txt">Отображать стр. приветствия</string>
     <string name="rate_app_txt">Оценить приложение</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,8 +57,8 @@
 
     <string name="settings_layout">Settings</string>
     <string name="settings_language">Language</string>
-    <string name="settings_language_rus">Russian</string>
-    <string name="settings_language_en">English</string>
+    <string name="settings_language_rus" translatable="false">Русский</string>
+    <string name="settings_language_en" translatable="false">English</string>
     <string name="music_txt">Music</string>
     <string name="onboarding_txt">Show onboard page</string>
     <string name="rate_app_txt">Rate the application</string>


### PR DESCRIPTION
Make language names untranslatable in the default locale, remove language names from the Russian locale