### PR TITLE
RUN-385 Music cuts out on configuration change

### DIFF
--- a/app/src/main/java/com/tnco/runar/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/tnco/runar/ui/activity/MainActivity.kt
@@ -104,11 +104,11 @@ class MainActivity : AppCompatActivity(), Navigator, AudioManager.OnAudioFocusCh
     }
 
     override fun onAudioFocusChange(focusChange: Int) {
-        if (focusChange <= 0) {
-            musicControllerViewModel.stopMusic()
-        } else {
-            musicControllerViewModel.startMusic()
-        }
+//        if (focusChange <= 0) {
+//            musicControllerViewModel.stopMusic()
+//        } else {
+//            musicControllerViewModel.startMusic()
+//        }
     }
 
     override fun onResume() {


### PR DESCRIPTION
temporary fix:
disable onAudioFocusChange callback

The callback is invoked when the audio focus changes. When the configuration is changed, onResume is invoked, which starts the music, and then this callback is called with the -1 parameter, which stops the music again. The purpose of this callback is not clear to me. If you disable it, the music does not stop, while the rest of the start and stop logic does not seem to be violated.
