### PR TITLE
RUN-385 Music cuts out on configuration change

### DIFF
--- a/app/src/main/java/com/tnco/runar/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/tnco/runar/ui/activity/MainActivity.kt
@@ -70,7 +70,6 @@ class MainActivity : AppCompatActivity(), Navigator, AudioManager.OnAudioFocusCh
         }
 
         audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
-        if (viewModel.sharedPreferencesRepository.settingsMusic == 1) getAudioFocus()
 
         val navHostFragment =
             supportFragmentManager.findFragmentById(R.id.fragmentContainer) as NavHostFragment
@@ -107,11 +106,11 @@ class MainActivity : AppCompatActivity(), Navigator, AudioManager.OnAudioFocusCh
     }
 
     override fun onAudioFocusChange(focusChange: Int) {
-//        if (focusChange <= 0) {
-//            musicControllerViewModel.stopMusic()
-//        } else {
-//            musicControllerViewModel.startMusic()
-//        }
+        if (focusChange <= 0) {
+            musicControllerViewModel.stopMusic()
+        } else {
+            musicControllerViewModel.startMusic()
+        }
     }
 
     override fun onResume() {


### PR DESCRIPTION
remove the redundant onAudioFocusChange callback that stopped the music and enable the logic of this callback