### PR TITLE
Fix inability to run generating several times in a row (RUN-369)

### DIFF
--- a/app/src/main/java/com/tnco/runar/ui/fragment/GeneratorBackground.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/GeneratorBackground.kt
@@ -192,7 +192,8 @@ class GeneratorBackground : Fragment() {
     }
 
     private fun showInternetConnectionError() {
-        requireActivity().viewModelStore.clear()
+        viewModel.clearData()
+        viewModel.cancelChildrenCoroutines()
         val uri = Uri.parse(
             InternalDeepLink.ConnectivityErrorFragment
                 .withArgs("${R.id.generatorStartFragment}")

--- a/app/src/main/java/com/tnco/runar/ui/fragment/RunePatternGenerator.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/RunePatternGenerator.kt
@@ -146,7 +146,8 @@ class RunePatternGenerator : Fragment() {
     }
 
     private fun showInternetConnectionError() {
-        requireActivity().viewModelStore.clear()
+        viewModel.clearData()
+        viewModel.cancelChildrenCoroutines()
         val uri = Uri.parse(
             InternalDeepLink.ConnectivityErrorFragment
                 .withArgs("${R.id.generatorStartFragment}")

--- a/app/src/main/java/com/tnco/runar/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/tnco/runar/ui/viewmodel/MainViewModel.kt
@@ -20,9 +20,7 @@ import com.tnco.runar.repository.backend.BackendRepository
 import com.tnco.runar.repository.backend.DataClassConverters
 import com.tnco.runar.util.NetworkMonitor
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.cancelChildren
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import okhttp3.ResponseBody
 import retrofit2.Response
 import javax.inject.Inject

--- a/app/src/main/java/com/tnco/runar/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/tnco/runar/ui/viewmodel/MainViewModel.kt
@@ -67,6 +67,7 @@ class MainViewModel @Inject constructor(
         try {
             val response = backendRepository.getRunes()
             runesResponse.postValue(handleRunesResponse(response))
+        } catch (_: CancellationException) {
         } catch (e: Exception) {
             runesResponse.postValue(NetworkResult.Error(e.toString()))
         }
@@ -87,6 +88,7 @@ class MainViewModel @Inject constructor(
         try {
             val response = backendRepository.getBackgroundInfo()
             handleBackgroundInfoResponse(response)
+        } catch (_: CancellationException) {
         } catch (e: Exception) {
             getBackgroundImages()
         }
@@ -99,6 +101,7 @@ class MainViewModel @Inject constructor(
 
         for (index in backgroundInfo.indices) {
             try {
+                if (!isActive) return@launch
                 val response = backendRepository.getBackgroundImage(
                     runesSelected,
                     runePattern[selectedRuneIndex],
@@ -107,6 +110,7 @@ class MainViewModel @Inject constructor(
                     1280
                 )
                 backgroundInfoResponse.postValue(handleBackgroundImageResponse(index, response))
+            } catch (_: CancellationException) {
             } catch (e: Exception) {
                 backgroundInfoResponse.postValue(NetworkResult.Error(e.toString()))
             }
@@ -119,6 +123,7 @@ class MainViewModel @Inject constructor(
         try {
             val response = backendRepository.getRunePattern(runesSelected)
             handleRunePatternResponse(response)
+        } catch (_: CancellationException) {
         } catch (e: Exception) {
             getRuneImages()
         }
@@ -134,8 +139,10 @@ class MainViewModel @Inject constructor(
 
         for (imgPath in runePattern) {
             try {
+                if (!isActive) return@launch
                 val response = backendRepository.getRuneImage(runesSelected, imgPath)
                 runesImagesResponse.postValue(handleRuneImagesResponse(response))
+            } catch (_: CancellationException) {
             } catch (e: Exception) {
                 runesImagesResponse.postValue(NetworkResult.Error(e.toString()))
             }
@@ -143,6 +150,15 @@ class MainViewModel @Inject constructor(
     }
 
     fun cancelChildrenCoroutines() = viewModelScope.coroutineContext.cancelChildren()
+
+    fun clearData() {
+        backgroundInfo = mutableListOf()
+        runePattern.clear()
+        runesImages.clear()
+        selectedRuneIndex = 0
+        shareURL = ""
+        runesSelected = ""
+    }
 
     private fun handleRunesResponse(
         response: Response<List<RunesResponse>>


### PR DESCRIPTION
* Добавил игнорирование CancellationException при отмене корутин. Это необходимо из-за того, что заглушка не делала ложные показы окна об отсутствии интернета у пользователя. Это исключение обрабатывать нет необходимости, оно только сигнализирует, что корутина была отменена.
* Добавил проверку на то, активна ли корутина в данный момент (isActive) или нет, чтобы корректно отменять корутины в которых циклически выполняются тяжелые операции (скачивание картинки).
* Заменил requireActivity().viewModelStore.clear() на выборочную очистку данных из viewModel-и, потому что предыдущий способ некорректно отрабатывал.
