### PR TITLE
Fix inability to run generating several times in a row (2) (RUN-369)

### DIFF
--- a/app/src/main/java/com/tnco/runar/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/tnco/runar/ui/viewmodel/MainViewModel.kt
@@ -67,6 +67,8 @@ class MainViewModel @Inject constructor(
             try {
                 val response = backendRepository.getRunes()
                 runesResponse.postValue(handleRunesResponse(response))
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 runesResponse.postValue(NetworkResult.Error(e.toString()))
             }
@@ -90,6 +92,8 @@ class MainViewModel @Inject constructor(
             try {
                 val response = backendRepository.getBackgroundInfo()
                 handleBackgroundInfoResponse(response)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 getBackgroundImages()
             }
@@ -114,6 +118,8 @@ class MainViewModel @Inject constructor(
                         1280
                     )
                     backgroundInfoResponse.postValue(handleBackgroundImageResponse(index, response))
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     backgroundInfoResponse.postValue(NetworkResult.Error(e.toString()))
                 }
@@ -129,6 +135,8 @@ class MainViewModel @Inject constructor(
             try {
                 val response = backendRepository.getRunePattern(runesSelected)
                 handleRunePatternResponse(response)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 getRuneImages()
             }
@@ -148,6 +156,8 @@ class MainViewModel @Inject constructor(
                 try {
                     val response = backendRepository.getRuneImage(runesSelected, imgPath)
                     runesImagesResponse.postValue(handleRuneImagesResponse(response))
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     runesImagesResponse.postValue(NetworkResult.Error(e.toString()))
                 }


### PR DESCRIPTION
Некорректное появление окна с требованием подключиться к интернету было связано с тем, что LiveData хранит последнее присвоенное ей знаначение, на которое мы подписываемся. При инициализации фрагмента мы считываем это последнее значение и, если оно "ошибка", то высвечивается заглушка. 

Корректное поведение было достигнуто следующими шагами:
* Перед вызовом метода, который шлет запрос в сеть, явно присваиваю дефолтное значение для переменной LiveData, а именно Loading.
* Удалил явное перехватывание исключения CancellationException. Корутина сама перехватывает это исключение и завершается корректно.
* Вынес в корутины только ту логику, которая должна выполняться в фоновом потоке, а не весь метод.