### PR TITLE
RUN-223 [Library]Delay displaying the message about the lack of Internet

### DIFF
--- a/app/src/main/java/com/tnco/runar/ui/fragment/LibraryFragment.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/LibraryFragment.kt
@@ -23,8 +23,8 @@ const val audioFeature = true
 class LibraryFragment : Fragment() {
     val viewModel: LibraryViewModel by viewModels()
 
-    override fun onStart() {
-        super.onStart()
+    override fun onResume() {
+        super.onResume()
         val noInternet = getString(R.string.internet_conn_error1)
         viewModel.isOnline.observeOnce(viewLifecycleOwner) { isOnline ->
             viewModel.errorLoad.observeOnce(viewLifecycleOwner) { errorLoad ->


### PR DESCRIPTION
fix an issue with prematurely displaying a toast by moving the toast display from onStart to onResume

[device-2023-02-26-202441.webm](https://user-images.githubusercontent.com/71641200/221413137-1a1537f1-01f8-4d14-9dd4-8f80b19ff4ef.webm)
