### PR TITLE
Fixed TopBarActions

### DIFF
--- a/app/src/main/java/com/tnco/runar/ui/fragment/FavouriteFragment.kt
+++ b/app/src/main/java/com/tnco/runar/ui/fragment/FavouriteFragment.kt
@@ -123,7 +123,7 @@ private fun Bars(navController: NavController) {
                     ) {
 
                         Column(
-                            modifier = Modifier.width(200.dp),
+                            modifier = Modifier.width(180.dp),
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
                             Text(
@@ -209,11 +209,17 @@ private fun TopBarActions(fontSize: Float, clickAction: () -> Unit) {
     IconButton(onClick = {
         SavedLayoutsDialog(context, fontSize, clickAction).showDialog()
     }) {
-        Icon(
-            painter = painterResource(id = R.drawable.ic_delete),
-            tint = colorResource(id = R.color.fav_top_bar_delete),
-            contentDescription = "trash"
-        )
+        Box(
+            Modifier
+                .fillMaxSize()
+                .absoluteOffset(x = 9.dp, y = 15.dp)
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_delete),
+                tint = colorResource(id = R.color.fav_top_bar_delete),
+                contentDescription = "trash"
+            )
+        }
     }
 }
 


### PR DESCRIPTION
1. Уменьшил ширину barText c 200 на 180.dp что бы текст продвинулся поближе к центру.
2. Поместил icon - ic_delete в box.
3. Выполнил размещение через absoluteOffset
Изначальное положение на Android 9
![photo_5292288423761137246_y](https://user-images.githubusercontent.com/99983028/230336204-c21e6ef1-4d3d-498d-b79b-cd00220eb48f.jpg)
Результат на Android 7
![Screenshot_20230406-135859](https://user-images.githubusercontent.com/99983028/230336556-c70fe50f-8d46-4249-9100-c39acd8a7efe.png)
Результат на Android 9
![photo_5292288423761137247_y](https://user-images.githubusercontent.com/99983028/230336715-76a8791a-3968-4ffa-a6f6-98546a0610fd.jpg)
Результат на Android 13
![photo_5292288423761137256_y](https://user-images.githubusercontent.com/99983028/230336796-495bcef3-b92f-4312-8104-9d61a0d2920b.jpg)


